### PR TITLE
support running programmatically & fix `--output` argument

### DIFF
--- a/docify.py
+++ b/docify.py
@@ -510,7 +510,7 @@ class Transformer(cst.CSTTransformer):
         return updated_node.with_changes(body=node_body)
 
 
-def main():
+def main(*args: str):
     arg_parser = ArgumentParser(
         description="A script to add docstrings to Python type stubs using reflection"
     )
@@ -553,7 +553,7 @@ def main():
         help="directory to write modified stubs to",
     )
 
-    args = arg_parser.parse_args()
+    args = arg_parser.parse_args(args)
 
     global VERBOSITY
     VERBOSITY += args.verbose
@@ -649,4 +649,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    main(*sys.argv)

--- a/docify.py
+++ b/docify.py
@@ -649,4 +649,4 @@ def main(*args: str):
 
 
 if __name__ == "__main__":
-    main(*sys.argv)
+    main(*sys.argv[1:])

--- a/docify.py
+++ b/docify.py
@@ -641,7 +641,7 @@ def main(*args: str):
             shutil.copymode(file_path, f.name)
             os.replace(f.name, file_path)
         else:
-            output_path = os.path.join(args.output_dir, file_relpath)
+            output_path = os.path.join(args.output, file_relpath)
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
             with open(output_path, "w") as f:


### PR DESCRIPTION
this allows you to run `docify` programmatically from python:

```py
from docify import main

main('./foo', 'verbose')
```

also the `--output` arg was crashing with this error, so i fixed that too:
```
AttributeError: 'Namespace' object has no attribute 'output_dir'. Did you mean: 'input_dir'?
```