### PR TITLE
Always use UTF-8 encoding for text file IO

### DIFF
--- a/docify.py
+++ b/docify.py
@@ -566,7 +566,7 @@ def run(
                 print_e(f"could not import {import_path}, {e}")
                 continue
 
-            with open(file_path, "r") as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 stub_source = f.read()
 
             try:
@@ -588,6 +588,7 @@ def run(
                     prefix=file_relpath + ".",
                     mode="w",
                     delete=False,
+                    encoding="utf-8",
                 )
                 try:
                     with f:
@@ -602,7 +603,7 @@ def run(
                 output_path = os.path.join(output_dir, file_relpath)
                 os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
-                with open(output_path, "w") as f:
+                with open(output_path, "w", encoding="utf-8") as f:
                     f.write(new_stub_cst.code)
 
 


### PR DESCRIPTION
Fixes the following error:

```
INFO: processing ftplib.pyi
  9%|███████▎                                                                         | 51/566 [00:04<00:47, 10.78it/s]
Traceback (most recent call last):
  File "D:\Repo\docify\docify.py", line 667, in <module>
    main(*sys.argv[1:])
  File "D:\Repo\docify\docify.py", line 663, in main
    run(**run_args)
  File "D:\Repo\docify\docify.py", line 606, in run
    f.write(new_stub_cst.code)
UnicodeEncodeError: 'cp950' codec can't encode character '\xb4' in position 2140: illegal multibyte sequence
```