### PR TITLE
Fix potential AttributeError during importing

### DIFF
--- a/docify.py
+++ b/docify.py
@@ -559,8 +559,8 @@ def run(
 
             try:
                 mod = importlib.import_module(import_path)
-            except ModuleNotFoundError:
-                print_w(f"could not import {import_path}, module not found")
+            except (AttributeError, ModuleNotFoundError) as e:
+                print_w(f"could not import {import_path}, {e}")
                 continue
             except ImportError as e:
                 print_e(f"could not import {import_path}, {e}")


### PR DESCRIPTION
Fix (ignore) the following error on `Windows` platform:

```
INFO: processing multiprocessing\pool.pyi
 82%|█████████████████████████████████████████████████████████████████▋              | 465/566 [00:23<00:05, 19.45it/s]
Traceback (most recent call last):
  File "D:\Repo\docify\docify.py", line 667, in <module>
    main(*sys.argv[1:])
  File "D:\Repo\docify\docify.py", line 663, in main
    run(**run_args)
  File "D:\Repo\docify\docify.py", line 561, in run
    mod = importlib.import_module(import_path)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\jfcherng\AppData\Local\Programs\Python\Python312\Lib\importlib\__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "C:\Users\jfcherng\AppData\Local\Programs\Python\Python312\Lib\multiprocessing\popen_fork.py", line 12, in <module>
    class Popen(object):
  File "C:\Users\jfcherng\AppData\Local\Programs\Python\Python312\Lib\multiprocessing\popen_fork.py", line 24, in Popen
    def poll(self, flag=os.WNOHANG):
                        ^^^^^^^^^^
AttributeError: module 'os' has no attribute 'WNOHANG'
```