### PR TITLE
add `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+version = "1.0.0"
+name = "docify"
+dependencies = [
+    "libcst==1.1.0",
+    "mypy-extensions==1.0.0",
+    "PyYAML==6.0.1",
+    "tqdm==4.66.4",
+    "typing-inspect==0.9.0",
+    "typing_extensions==4.12.2",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-libcst==1.1.0
-mypy-extensions==1.0.0
-PyYAML==6.0.1
-tqdm==4.66.4
-typing-inspect==0.9.0
-typing_extensions==4.12.2


### PR DESCRIPTION
fixes errors when installing docify from github